### PR TITLE
Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_analyze.yml
+++ b/.github/workflows/build_analyze.yml
@@ -21,6 +21,8 @@ jobs:
   make:
     name: Make
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Make


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/48](https://github.com/DavidLee18/42_webserv/security/code-scanning/48)

To fix the problem, add an explicit `permissions` block to the `make` job so that the `GITHUB_TOKEN` is restricted to the minimal required scope. Since the `make` job only checks out the repository and runs `make`, it should only need read access to repository contents.

Concretely, in `.github/workflows/build_analyze.yml`, under `jobs: make:`, add:

```yaml
permissions:
  contents: read
```

between `runs-on: ubuntu-latest` and `steps:` (or in any valid position within that job). No imports or additional methods are needed, as this is purely a workflow configuration change. Existing functionality is preserved: the job will still run `make`, just with a more limited `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
