### PR TITLE
Potential fix for code scanning alert no. 31: Inconsistent definition of copy constructor and assignment ('Rule of Two')

### DIFF
--- a/src/WebserverConfig.hpp
+++ b/src/WebserverConfig.hpp
@@ -31,6 +31,15 @@ public:
       : default_mime(other.default_mime), type_map(other.type_map),
         ServerConfig_map(other.ServerConfig_map) {};
 
+  WebserverConfig &operator=(const WebserverConfig &other) {
+    if (this != &other) {
+      this->default_mime = other.default_mime;
+      this->type_map = other.type_map;
+      this->ServerConfig_map = other.ServerConfig_map;
+    }
+    return *this;
+  }
+
   const std::string &Get_default_mime(void) const { return default_mime; }
   const std::map<std::string, std::string> &Get_Type_map(void) const {
     return type_map;

--- a/src/WebserverConfig.hpp
+++ b/src/WebserverConfig.hpp
@@ -36,6 +36,7 @@ public:
       this->default_mime = other.default_mime;
       this->type_map = other.type_map;
       this->ServerConfig_map = other.ServerConfig_map;
+      this->err_meg.clear();
     }
     return *this;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/31](https://github.com/DavidLee18/42_webserv/security/code-scanning/31)

In general, to fix "Rule of Two" issues, either (a) remove the user-defined copy constructor/assignment so the compiler generates both consistently, or (b) add the missing corresponding function (copy constructor or copy assignment) so that copy construction and copy assignment have aligned behavior. If copying should be disallowed, then both should be explicitly deleted.

Here, we already have a copy constructor that copies `default_mime`, `type_map`, and `ServerConfig_map`, but not `err_meg`. The implicit copy assignment operator would copy `err_meg` as well, which would make assignment behave differently from construction. To preserve current behavior and avoid changing external semantics, we should add a copy assignment operator that copies the same subset of members as the copy constructor: `default_mime`, `type_map`, and `ServerConfig_map`, and leaves `err_meg` unchanged. This ensures consistency between copy construction and assignment without altering how `err_meg` is handled compared to the current copy constructor.

Concretely, in `src/WebserverConfig.hpp`, in the `public` section of `WebserverConfig`, directly after the existing copy constructor definition, we will add:

```cpp
WebserverConfig &operator=(const WebserverConfig &other) {
  if (this != &other) {
    this->default_mime = other.default_mime;
    this->type_map = other.type_map;
    this->ServerConfig_map = other.ServerConfig_map;
  }
  return *this;
}
```

No new headers or other definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
