### PR TITLE
Potential fix for code scanning alert no. 35: Large object passed by value

### DIFF
--- a/src/cgi_1_1.cpp
+++ b/src/cgi_1_1.cpp
@@ -119,7 +119,7 @@ CgiMetaVar CgiMetaVar::content_length(unsigned int l) {
   return CgiMetaVar(CONTENT_LENGTH, (CgiMetaVar::Val){.content_length = l});
 }
 
-CgiMetaVar CgiMetaVar::content_type(ContentType ty) {
+CgiMetaVar CgiMetaVar::content_type(const ContentType &ty) {
   return CgiMetaVar(CONTENT_TYPE,
                     (CgiMetaVar::Val){.content_type = new ContentType(ty)});
 }

--- a/src/cgi_1_1.h
+++ b/src/cgi_1_1.h
@@ -490,7 +490,7 @@ private:
   CgiMetaVar(Name n, Val v) : name(n), val(v) {}
   static CgiMetaVar auth_type(CgiAuthType);
   static CgiMetaVar content_length(unsigned int);
-  static CgiMetaVar content_type(ContentType);
+  static CgiMetaVar content_type(const ContentType &);
   static CgiMetaVar gateway_interface(GatewayInterface);
   static CgiMetaVar path_info(std::list<std::string>);
   static CgiMetaVar path_translated(std::string);


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/35](https://github.com/DavidLee18/42_webserv/security/code-scanning/35)

In general, to fix “large object passed by value” issues, change function parameters of large types from pass‑by‑value to pass‑by‑reference (usually `const T&`), so only a pointer‑sized reference is passed on the stack instead of the full object. The function body can then use the referenced object as before (with `*` where a copy is needed) or avoid copying altogether if possible.

For this specific case, the best minimal‑impact fix is to change the signature of `CgiMetaVar::content_type` to take its `ContentType` argument as a `const ContentType&` instead of by value. Inside the function, we still need to construct a heap‑allocated `ContentType` with the same value, so we should call `new ContentType(ty)` where `ty` is now a reference. This preserves the existing semantics—`CgiMetaVar` owns a heap‑allocated copy of the provided `ContentType`—while avoiding the extra copy into the parameter’s stack storage. No additional methods, imports, or type changes are needed, and all existing call sites that pass a `ContentType` will continue to compile because binding to `const T&` is compatible with passing an lvalue or rvalue of type `T`.

The change should be made in `src/cgi_1_1.cpp` around line 122, replacing the function parameter declaration and adjusting the implementation accordingly (the implementation already works the same since `ty` is used directly). No other parts of the file need to be modified for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
