### PR TITLE
Potential fix for code scanning alert no. 32: Declaration hides variable

### DIFF
--- a/src/ServerConfig.cpp
+++ b/src/ServerConfig.cpp
@@ -307,8 +307,8 @@ static bool is_pattern(std::string line) {
   size_t count = 0;
   size_t start = 0;
   while (1) {
-    size_t pos = inside.find('|', start);
-    std::string ext = inside.substr(start, pos - start);
+    size_t pipePos = inside.find('|', start);
+    std::string ext = inside.substr(start, pipePos - start);
     if (ext.empty())
       return false;
     for (size_t i = 0; i < ext.size(); ++i) {
@@ -316,9 +316,9 @@ static bool is_pattern(std::string line) {
         return false;
     }
     count++;
-    if (pos == std::string::npos)
+    if (pipePos == std::string::npos)
       break;
-    start = pos + 1;
+    start = pipePos + 1;
   }
   return count >= 2;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/32](https://github.com/DavidLee18/42_webserv/security/code-scanning/32)

In general, to fix “declaration hides variable” issues, you rename one of the variables so they no longer share the same identifier, or refactor the code to reuse a single variable where that makes sense. Here, the outer `pos` (used for `"*."` detection) is logically separate from the inner `pos` (used for positions of `'|'` inside `inside`), so the cleanest change is to rename the inner `pos` to something like `pipePos` or `sepPos`. This preserves behavior while removing shadowing.

Concretely, in `src/ServerConfig.cpp` within `static bool is_pattern(std::string line)`, update the declaration `size_t pos = inside.find('|', start);` at line 310 to use a new name (e.g., `pipePos`), and update all uses of that inner variable inside the `while` loop: the `substr` call, the `if (pos == std::string::npos)` condition, and the `start = pos + 1;` assignment. No new methods or imports are needed; only a local variable rename within the shown snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
