### PR TITLE
Potential fix for code scanning alert no. 44: Poorly documented large function

### DIFF
--- a/src/cgi_1_1.h
+++ b/src/cgi_1_1.h
@@ -334,9 +334,16 @@ public:
     }
   }
 
+  // Assigns from another CgiMetaVar, performing a deep copy of the active value.
+  // The operator first releases any currently owned dynamic resources associated
+  // with this->name, then copies the discriminator and value from 'other' in a
+  // way that mirrors the copy constructor. Self-assignment is explicitly guarded
+  // against so we never delete resources before reading from them.
   CgiMetaVar &operator=(const CgiMetaVar &other) {
+    // Protect against self-assignment; required because we delete current
+    // resources before copying from 'other'.
     if (this != &other) {
-      // Clean up existing value
+      // Clean up the value currently selected by 'name' before overwriting it.
       switch (name) {
       case AUTH_TYPE:
         delete val.auth_type;


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/44](https://github.com/DavidLee18/42_webserv/security/code-scanning/44)

In general terms, the best fix is to add clear, focused comments documenting the purpose and behavior of `CgiMetaVar::operator=`, especially how it manages the `name` discriminator and the `val` union members, its handling of self‑assignment, and its symmetry with the copy constructor. This increases the proportion of comment lines above the rule’s threshold without altering functionality.

Concretely, in `src/cgi_1_1.h`, inside the definition of `CgiMetaVar::operator=`, we should:
- Add a brief function‑level comment immediately above the definition summarizing what the assignment operator does (deep copy, union/discriminated type semantics, self‑assignment protection).
- Add explanatory comments within the body:
  - Clarify the purpose of the initial self‑assignment check.
  - Clarify that the first `switch (name)` is responsible for releasing the currently active member corresponding to `this->name`.
  - (If visible in the rest of the function) clarify that the subsequent logic copies `other`’s `name` and `val` consistently, mirroring the copy constructor.
These comments should be minimal but precise, aligned with the existing style (C++ `//` comments), and they should not introduce any new code or change control flow. No new headers or external libraries are needed, and we do not touch any other functions or files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
