### PR TITLE
Potential fix for code scanning alert no. 30: Short global name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 #include "webserv.h"
 #include "ServerSocket.hpp"
 
-volatile sig_atomic_t sig = 0;
+volatile sig_atomic_t g_receivedSignal = 0;
 
 int main(const int argc, char *argv[]) {
   (void)argc;
@@ -39,4 +39,4 @@ int main(const int argc, char *argv[]) {
   return 0;
 }
 
-void wrap_up(const int signum) throw() { sig = signum; }
+void wrap_up(const int signum) throw() { g_receivedSignal = signum; }

--- a/src/webserv.h
+++ b/src/webserv.h
@@ -39,6 +39,6 @@
 #include <unistd.h>
 
 void wrap_up(int) throw();
-extern volatile sig_atomic_t sig;
+extern volatile sig_atomic_t g_receivedSignal;
 
 #endif


### PR DESCRIPTION
Potential fix for [https://github.com/DavidLee18/42_webserv/security/code-scanning/30](https://github.com/DavidLee18/42_webserv/security/code-scanning/30)

In general, to fix this kind of problem, rename the short global variable to a longer, descriptive name that clearly communicates its role and global nature, and then update all references to it accordingly. For globals, a prefix such as `g_` (for “global”) or a more project-specific convention can help distinguish them from locals.

For this specific case in `src/main.cpp`, you can rename `sig` at line 4 to something like `g_receivedSignal` to indicate that it stores the most recently received signal number. Then adjust the signal handler `wrap_up` to assign to `g_receivedSignal` instead of `sig`. We are constrained to only modify the shown code in `src/main.cpp`, so we must assume any other references to this variable are either in this file (but outside the snippet) or non-existent. Within the snippet, the only reference is in `wrap_up`, so that is safe to update. No new methods or imports are necessary; we only change the identifier name while keeping the type, storage class (`volatile sig_atomic_t`), and functionality identical.

Concretely:
- In `src/main.cpp` line 4, change `sig` to `g_receivedSignal`.
- In `wrap_up` (line 42), change the assignment target from `sig` to `g_receivedSignal`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
