### PR TITLE
Split CgiDelegate/UwsgiDelegate execute() into start() + handle_event()

### DIFF
--- a/src/cgi_1_1.cpp
+++ b/src/cgi_1_1.cpp
@@ -1122,29 +1122,16 @@ unsigned char to_upper(unsigned char c) {
 // CgiDelegate implementation
 
 CgiDelegate::CgiDelegate(const Request &req, const std::string &script)
-    : env(), script_path(script), request(req) {
+    : env(), script_path(script), request(req),
+      _state(NOT_STARTED), _epoll(NULL), _pid(-1),
+      _stdin_raw(-1), _stdout_raw(-1),
+      _stdin_epoll(NULL), _stdout_epoll(NULL),
+      _body(), _total_written(0), _output(), _error() {
   // Parse the HTTP request to CgiInput
   Result<CgiInput> parse_result = CgiInput::Parser::parse(req);
   if (parse_result.error().empty()) {
     env = parse_result.value();
   }
-}
-
-// Returns the number of milliseconds remaining until the deadline.
-// If timeout_ms <= 0 the caller requested no deadline and -1 is returned
-// (epoll_wait interprets -1 as "wait indefinitely").
-// Returns 0 when the deadline has already passed.
-static int remaining_ms(long long start_ms, int timeout_ms) {
-  if (timeout_ms <= 0)
-    return -1;
-  struct timeval tv_now;
-  gettimeofday(&tv_now, NULL);
-  long long now_ms = (long long)tv_now.tv_sec * 1000 + tv_now.tv_usec / 1000;
-  // Guard against clock going backwards (e.g. NTP adjustment)
-  if (now_ms < start_ms)
-    return timeout_ms;
-  long long rem = (long long)timeout_ms - (now_ms - start_ms);
-  return (rem > 0) ? (int)rem : 0;
 }
 
 static const int kWaitpidPollIntervalUs = 1000;
@@ -1153,10 +1140,13 @@ static const int kWaitpidReapAttempts =
     (kMaxReapWaitMs * 1000) / kWaitpidPollIntervalUs;
 
 // Reap child without risking an unbounded blocking wait.
-static bool waitpid_nohang(pid_t pid) {
-  int status;
+// Writes the exit status through 'status' when a child is successfully
+// reaped, leaves it untouched otherwise.
+static bool waitpid_nohang(pid_t pid, int *status) {
+  int dummy;
+  int *s = (status != NULL) ? status : &dummy;
   for (int i = 0; i < kWaitpidReapAttempts; ++i) {
-    pid_t wr = waitpid(pid, &status, WNOHANG);
+    pid_t wr = waitpid(pid, s, WNOHANG);
     if (wr == pid) {
       return true;
     }
@@ -1169,32 +1159,64 @@ static bool waitpid_nohang(pid_t pid) {
 
 static void terminate_child(pid_t pid) {
   kill(pid, SIGKILL);
-  (void)waitpid_nohang(pid);
+  (void)waitpid_nohang(pid, NULL);
 }
 
-Result<std::string> CgiDelegate::execute(int timeout_ms, EPoll *epoll) {
+void CgiDelegate::_cleanup_epoll() {
+  if (_epoll == NULL)
+    return;
+  if (_stdin_epoll != NULL) {
+    _epoll->del_fd(*_stdin_epoll);
+    _stdin_epoll = NULL;
+  }
+  if (_stdout_epoll != NULL) {
+    _epoll->del_fd(*_stdout_epoll);
+    _stdout_epoll = NULL;
+  }
+  _stdin_raw = -1;
+  _stdout_raw = -1;
+}
 
+void CgiDelegate::_fail(const std::string &msg) {
+  _state = FAILED;
+  _error = msg;
+  _cleanup_epoll();
+  if (_pid > 0) {
+    terminate_child(_pid);
+    _pid = -1;
+  }
+}
+
+// Phase 1: create pipes, fork the CGI process, and register the parent's
+// pipe ends with the shared epoll instance. No epoll_wait() is performed
+// here - the caller's main loop is the sole owner of epoll_wait() and
+// will drive handle_event() for each event delivered.
+Result<Void> CgiDelegate::start(EPoll *epoll) {
   if (epoll == NULL) {
-    return ERR(std::string, "EPoll instance required");
+    return ERR(Void, "EPoll instance required");
+  }
+  if (_state != NOT_STARTED) {
+    return ERR(Void, "CgiDelegate::start() already called");
   }
 
-  // Capture start time for end-to-end deadline tracking
-  struct timeval tv_start;
-  gettimeofday(&tv_start, NULL);
-  long long start_ms =
-      (long long)tv_start.tv_sec * 1000 + tv_start.tv_usec / 1000;
+  _epoll = epoll;
+  _body = request.get_body();
 
   // Create pipes for communication
   int stdin_pipe[2];
   int stdout_pipe[2];
 
   if (pipe(stdin_pipe) == -1) {
-    return ERR(std::string, "Failed to create stdin pipe");
+    _state = FAILED;
+    _error = "Failed to create stdin pipe";
+    return ERR(Void, _error);
   }
   if (pipe(stdout_pipe) == -1) {
     close(stdin_pipe[0]);
     close(stdin_pipe[1]);
-    return ERR(std::string, "Failed to create stdout pipe");
+    _state = FAILED;
+    _error = "Failed to create stdout pipe";
+    return ERR(Void, _error);
   }
 
   // Fork the process
@@ -1204,17 +1226,16 @@ Result<std::string> CgiDelegate::execute(int timeout_ms, EPoll *epoll) {
     close(stdin_pipe[1]);
     close(stdout_pipe[0]);
     close(stdout_pipe[1]);
-    return ERR(std::string, "Failed to fork process");
+    _state = FAILED;
+    _error = "Failed to fork process";
+    return ERR(Void, _error);
   }
 
   if (pid == 0) {
     // Child process
+    close(stdin_pipe[1]);
+    close(stdout_pipe[0]);
 
-    // Close unused pipe ends
-    close(stdin_pipe[1]);  // Close write end of stdin pipe
-    close(stdout_pipe[0]); // Close read end of stdout pipe
-
-    // Redirect stdin and stdout
     if (dup2(stdin_pipe[0], STDIN_FILENO) == -1) {
       std::cerr << "Failed to redirect stdin" << std::endl;
       exit(1);
@@ -1223,24 +1244,17 @@ Result<std::string> CgiDelegate::execute(int timeout_ms, EPoll *epoll) {
       std::cerr << "Failed to redirect stdout" << std::endl;
       exit(1);
     }
-
-    // Close the pipe file descriptors after duplication
     close(stdin_pipe[0]);
     close(stdout_pipe[1]);
 
-    // Prepare environment variables
     char **envp = env.to_envp();
-
-    // Prepare arguments
     char *argv[2];
     argv[0] = const_cast<char *>(script_path.c_str());
     argv[1] = NULL;
 
-    // Execute the CGI script
     execve(script_path.c_str(), argv, envp);
 
-    // If execve returns, it failed
-    // Clean up allocated memory before exit
+    // execve failed
     for (size_t i = 0; envp[i] != NULL; i++) {
       delete[] envp[i];
     }
@@ -1251,262 +1265,268 @@ Result<std::string> CgiDelegate::execute(int timeout_ms, EPoll *epoll) {
   }
 
   // Parent process
+  close(stdin_pipe[0]);
+  close(stdout_pipe[1]);
 
-  // Close unused pipe ends
-  close(stdin_pipe[0]);  // Close read end of stdin pipe
-  close(stdout_pipe[1]); // Close write end of stdout pipe
+  _pid = pid;
+  _stdin_raw = stdin_pipe[1];
+  _stdout_raw = stdout_pipe[0];
 
-  // Create FileDescriptor objects for the pipes
+  // Wrap the pipe ends so they are closed automatically. add_fd() takes
+  // ownership of each FileDescriptor by moving it into its internal list.
   Result<FileDescriptor> stdin_fd_res = FileDescriptor::from_raw(stdin_pipe[1]);
   if (!stdin_fd_res.error().empty()) {
     close(stdin_pipe[1]);
     close(stdout_pipe[0]);
-    terminate_child(pid);
-    return ERR(std::string, "Failed to create stdin FileDescriptor");
+    terminate_child(_pid);
+    _pid = -1;
+    _stdin_raw = -1;
+    _stdout_raw = -1;
+    _state = FAILED;
+    _error = "Failed to create stdin FileDescriptor";
+    return ERR(Void, _error);
   }
   FileDescriptor stdin_fd = stdin_fd_res.value();
 
   Result<FileDescriptor> stdout_fd_res =
       FileDescriptor::from_raw(stdout_pipe[0]);
   if (!stdout_fd_res.error().empty()) {
-    // stdin_pipe[1] is owned by stdin_fd, will be closed automatically
+    // stdin_fd destructor closes stdin_pipe[1]
     close(stdout_pipe[0]);
-    terminate_child(pid);
-    return ERR(std::string, "Failed to create stdout FileDescriptor");
+    terminate_child(_pid);
+    _pid = -1;
+    _stdin_raw = -1;
+    _stdout_raw = -1;
+    _state = FAILED;
+    _error = "Failed to create stdout FileDescriptor";
+    return ERR(Void, _error);
   }
   FileDescriptor stdout_fd = stdout_fd_res.value();
 
-  // Set pipe FDs to non-blocking before adding to EPoll.
-  // This is required for correct EPoll usage: without O_NONBLOCK, read/write
-  // could block even after EPoll signals readiness (e.g. EAGAIN race), and
-  // EAGAIN must be detectable to correctly drain data in the event loop.
+  // Non-blocking is mandatory: epoll readiness does not imply non-blocking
+  // semantics of read/write, and partial IO is expected in the event loop.
   Result<Void> stdin_nb = stdin_fd.set_nonblocking();
   if (!stdin_nb.has_value()) {
-    // stdin_fd and stdout_fd destructors close the pipe ends
-    terminate_child(pid);
-    return ERR(std::string,
-               "Failed to set stdin pipe to non-blocking mode");
+    terminate_child(_pid);
+    _pid = -1;
+    _stdin_raw = -1;
+    _stdout_raw = -1;
+    _state = FAILED;
+    _error = "Failed to set stdin pipe to non-blocking mode";
+    return ERR(Void, _error);
   }
   Result<Void> stdout_nb = stdout_fd.set_nonblocking();
   if (!stdout_nb.has_value()) {
-    // stdin_fd and stdout_fd destructors close the pipe ends
-    terminate_child(pid);
-    return ERR(std::string,
-               "Failed to set stdout pipe to non-blocking mode");
+    terminate_child(_pid);
+    _pid = -1;
+    _stdin_raw = -1;
+    _stdout_raw = -1;
+    _state = FAILED;
+    _error = "Failed to set stdout pipe to non-blocking mode";
+    return ERR(Void, _error);
   }
 
-  // Prepare request body for writing
-  std::string body_str = request.get_body();
-
-  // Write request body to CGI stdin if present, using EPoll to check
-  // writability
-  if (!body_str.empty()) {
-    // Add stdin_fd to epoll for writing
-    const FileDescriptor *stdin_fd_ptr = &stdin_fd;
-    Event write_event(stdin_fd_ptr, false, true, false, false, false, false);
+  // Register stdin for EPOLLOUT only when we actually have a body to send.
+  // If there is no body, let the stdin_fd destructor close the pipe so the
+  // CGI script sees EOF on its stdin.
+  if (!_body.empty()) {
+    const FileDescriptor *in_ptr = &stdin_fd;
+    Event write_event(in_ptr, false, true, false, false, true, true);
     Option write_option(false, false, false, false);
-    Result<FileDescriptor *> add_result =
-        epoll->add_fd(stdin_fd, write_event, write_option);
-
-    if (!add_result.has_value()) {
-      // FileDescriptor destructors will close the pipes
-      terminate_child(pid);
-      return ERR(std::string, "Failed to add stdin to epoll");
+    Result<FileDescriptor *> add_res =
+        _epoll->add_fd(stdin_fd, write_event, write_option);
+    if (!add_res.has_value()) {
+      terminate_child(_pid);
+      _pid = -1;
+      _stdin_raw = -1;
+      _stdout_raw = -1;
+      _state = FAILED;
+      _error = "Failed to add stdin to epoll";
+      return ERR(Void, _error);
     }
-    FileDescriptor *stdin_epoll = add_result.value();
-
-    size_t total_written = 0;
-    while (total_written < body_str.length()) {
-      // Wait for the fd to be writable (respects the end-to-end deadline)
-      int rem = remaining_ms(start_ms, timeout_ms);
-      if (rem == 0) {
-        epoll->del_fd(*stdin_epoll);
-        terminate_child(pid);
-        return ERR(std::string, "Timeout waiting for stdin writability");
-      }
-      Result<Events> wait_result = epoll->wait(rem);
-      if (!wait_result.error().empty()) {
-        epoll->del_fd(*stdin_epoll);
-        // FileDescriptor destructors will close the pipes
-        terminate_child(pid);
-        return ERR(std::string, "EPoll wait failed for stdin");
-      }
-
-      Events events = wait_result.value();
-
-      // Check if timeout occurred (no events returned)
-      if (events.is_end()) {
-        epoll->del_fd(*stdin_epoll);
-        // FileDescriptor destructors will close the pipes
-        terminate_child(pid);
-        return ERR(std::string, "Timeout waiting for stdin writability");
-      }
-
-      bool fd_ready = false;
-
-      for (; !events.is_end(); ++events) {
-        Result<const Event *> event_result = *events;
-        if (!event_result.error().empty()) {
-          continue;
-        }
-        const Event *ev = event_result.value();
-        if (*ev->fd == stdin_pipe[1] && ev->out) {
-          fd_ready = true;
-          break;
-        }
-      }
-
-      if (!fd_ready) {
-        // Got events but not for our fd, continue waiting
-        continue;
-      }
-
-      // FD is ready, perform write
-      ssize_t written = write(stdin_pipe[1], body_str.c_str() + total_written,
-                              body_str.length() - total_written);
-      if (written < 0) {
-        epoll->del_fd(*stdin_epoll);
-        // FileDescriptor destructors will close the pipes
-        terminate_child(pid);
-        return ERR(std::string, "Failed to write to CGI stdin");
-      } else if (written == 0) {
-        // Pipe closed by reader (child process)
-        epoll->del_fd(*stdin_epoll);
-        // FileDescriptor destructors will close the pipes
-        terminate_child(pid);
-        return ERR(std::string, "CGI process closed stdin prematurely");
-      }
-      total_written += static_cast<size_t>(written);
-    }
-
-    // Remove stdin from epoll and close it
-    epoll->del_fd(*stdin_epoll);
-  }
-  // Close stdin by letting stdin_fd go out of scope
-  // (Manual close would be a double-close bug)
-  {
-    // Create a scope to destroy stdin_fd and close stdin_pipe[1]
-    FileDescriptor temp_fd = stdin_fd;
-    // temp_fd destructor will close stdin_pipe[1]
+    _stdin_epoll = add_res.value();
+  } else {
+    // No body: the stdin_fd local will go out of scope and close the pipe.
+    _stdin_raw = -1;
   }
 
-  // Add stdout_fd to epoll for reading
-  const FileDescriptor *stdout_fd_ptr = &stdout_fd;
-  Event read_event(stdout_fd_ptr, true, false, false, false, false, false);
+  // Register stdout for EPOLLIN (plus err/hup so we notice child exit).
+  const FileDescriptor *out_ptr = &stdout_fd;
+  Event read_event(out_ptr, true, false, true, false, true, true);
   Option read_option(false, false, false, false);
-  Result<FileDescriptor *> add_stdout_result =
-      epoll->add_fd(stdout_fd, read_event, read_option);
-
-  if (!add_stdout_result.has_value()) {
-    // stdout_fd destructor will close stdout_pipe[0]
-    terminate_child(pid);
-    return ERR(std::string, "Failed to add stdout to epoll");
+  Result<FileDescriptor *> add_out_res =
+      _epoll->add_fd(stdout_fd, read_event, read_option);
+  if (!add_out_res.has_value()) {
+    if (_stdin_epoll != NULL) {
+      _epoll->del_fd(*_stdin_epoll);
+      _stdin_epoll = NULL;
+    }
+    terminate_child(_pid);
+    _pid = -1;
+    _stdin_raw = -1;
+    _stdout_raw = -1;
+    _state = FAILED;
+    _error = "Failed to add stdout to epoll";
+    return ERR(Void, _error);
   }
-  FileDescriptor *stdout_epoll = add_stdout_result.value();
+  _stdout_epoll = add_out_res.value();
 
-  // Read output using EPoll to check readability
-  std::string output;
-  char buffer[4096];
+  _state = RUNNING;
+  return OKV;
+}
 
-  while (true) {
-    // Wait for data to be available (respects the end-to-end deadline)
-    int rem = remaining_ms(start_ms, timeout_ms);
-    if (rem == 0) {
-      epoll->del_fd(*stdout_epoll);
-      terminate_child(pid);
-      return ERR(std::string, "CGI execution timeout");
+// Phase 2: consume one event delivered by the caller's shared epoll_wait.
+// Caller is expected to filter events and only forward those belonging to
+// fds this delegate registered. Unknown events are ignored.
+Result<Void> CgiDelegate::handle_event(const Event *ev) {
+  if (_state != RUNNING) {
+    return OKV;
+  }
+  if (ev == NULL || ev->fd == NULL) {
+    return OKV;
+  }
+
+  const bool is_stdin =
+      (_stdin_epoll != NULL && _stdin_raw != -1 && *ev->fd == _stdin_raw);
+  const bool is_stdout =
+      (_stdout_epoll != NULL && _stdout_raw != -1 && *ev->fd == _stdout_raw);
+
+  if (!is_stdin && !is_stdout) {
+    return OKV; // not for us
+  }
+
+  if (is_stdin) {
+    if (ev->err) {
+      _fail("EPoll error on CGI stdin");
+      return ERR(Void, _error);
     }
-    Result<Events> wait_result = epoll->wait(rem);
-    if (!wait_result.error().empty()) {
-      epoll->del_fd(*stdout_epoll);
-      // stdout_fd destructor will close stdout_pipe[0]
-      terminate_child(pid);
-      return ERR(std::string, "EPoll wait failed for stdout");
-    }
-
-    Events events = wait_result.value();
-
-    // Check if timeout occurred (no events returned)
-    if (events.is_end()) {
-      epoll->del_fd(*stdout_epoll);
-      // stdout_fd destructor will close stdout_pipe[0]
-      terminate_child(pid);
-      return ERR(std::string, "CGI execution timeout");
-    }
-
-    bool fd_ready = false;
-
-    for (; !events.is_end(); ++events) {
-      Result<const Event *> event_result = *events;
-      if (!event_result.error().empty()) {
-        continue;
-      }
-      const Event *ev = event_result.value();
-      // Also check hup/rdhup: when the write end of the pipe is closed (child
-      // exits), EPoll delivers EPOLLHUP even if EPOLLIN was not requested.
-      // Without this check, the loop would never set fd_ready=true on the final
-      // HUP-only event, spinning forever in level-triggered mode.
-      if (*ev->fd == stdout_pipe[0] && (ev->in || ev->hup || ev->rdhup)) {
-        fd_ready = true;
-        break;
+    if (ev->out && _total_written < _body.length()) {
+      ssize_t written = write(_stdin_raw, _body.c_str() + _total_written,
+                              _body.length() - _total_written);
+      if (written > 0) {
+        _total_written += static_cast<size_t>(written);
+      } else if (written == 0) {
+        _fail("CGI process closed stdin prematurely");
+        return ERR(Void, _error);
+      } else {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+          return OKV;
+        }
+        _fail("Failed to write to CGI stdin");
+        return ERR(Void, _error);
       }
     }
-
-    if (!fd_ready) {
-      // Got events but not for our fd, continue waiting
-      continue;
+    if (_total_written >= _body.length()) {
+      // Done writing: drop stdin from epoll, which also closes the pipe,
+      // signalling EOF to the CGI script.
+      _epoll->del_fd(*_stdin_epoll);
+      _stdin_epoll = NULL;
+      _stdin_raw = -1;
     }
+    return OKV;
+  }
 
-    // FD is ready, perform read
-    ssize_t bytes_read = read(stdout_pipe[0], buffer, sizeof(buffer));
-
+  // is_stdout
+  if (ev->in || ev->hup || ev->rdhup) {
+    char buffer[4096];
+    ssize_t bytes_read = read(_stdout_raw, buffer, sizeof(buffer));
     if (bytes_read > 0) {
-      output.append(buffer, static_cast<size_t>(bytes_read));
-    } else if (bytes_read == 0) {
-      // EOF reached
-      break;
-    } else {
-      // Read error
-      epoll->del_fd(*stdout_epoll);
-      // stdout_fd destructor will close stdout_pipe[0]
-      terminate_child(pid);
-      return ERR(std::string, "Failed to read from CGI stdout");
+      _output.append(buffer, static_cast<size_t>(bytes_read));
+      return OKV;
     }
+    if (bytes_read < 0) {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        return OKV;
+      }
+      _fail("Failed to read from CGI stdout");
+      return ERR(Void, _error);
+    }
+
+    // bytes_read == 0: EOF, drain any remaining IO bookkeeping.
+    _epoll->del_fd(*_stdout_epoll);
+    _stdout_epoll = NULL;
+    _stdout_raw = -1;
+    if (_stdin_epoll != NULL) {
+      _epoll->del_fd(*_stdin_epoll);
+      _stdin_epoll = NULL;
+      _stdin_raw = -1;
+    }
+
+    int status = 0;
+    if (!waitpid_nohang(_pid, &status)) {
+      terminate_child(_pid);
+      _pid = -1;
+      _fail("CGI child process did not exit cleanly");
+      return ERR(Void, _error);
+    }
+    _pid = -1;
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+      _state = FAILED;
+      _error = "CGI script failed";
+      return ERR(Void, _error);
+    }
+
+    _state = COMPLETE;
+    return OKV;
   }
 
-  // Remove stdout from epoll and close it
-  epoll->del_fd(*stdout_epoll);
-  // stdout_fd destructor will close stdout_pipe[0] when it goes out of scope
-
-  // Wait for child process
-  int status;
-  while (true) {
-    pid_t wr = waitpid(pid, &status, WNOHANG);
-    if (wr == pid) {
-      break;
-    }
-    if (wr == -1) {
-      return ERR(std::string, "Failed to wait for child process");
-    }
-    int rem = remaining_ms(start_ms, timeout_ms);
-    if (rem == 0) {
-      terminate_child(pid);
-      return ERR(std::string, "CGI execution timeout");
-    }
-    long long rem_us = static_cast<long long>(rem) * 1000;
-    int sleep_us = rem_us < kWaitpidPollIntervalUs
-                       ? static_cast<int>(rem_us)
-                       : kWaitpidPollIntervalUs;
-    usleep(static_cast<useconds_t>(sleep_us));
+  if (ev->err) {
+    _fail("EPoll error on CGI stdout");
+    return ERR(Void, _error);
   }
+  return OKV;
+}
 
-  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-    return ERR(std::string, "CGI script failed");
+Result<std::string> CgiDelegate::result() const {
+  if (_state == FAILED) {
+    return ERR(std::string, _error);
   }
+  if (_state != COMPLETE) {
+    return ERR(std::string, "CGI execution not complete");
+  }
+  return OK(std::string, _output);
+}
 
-  return OK(std::string, output);
+// DEPRECATED: synchronous wrapper retained only so that legacy callers
+// compile during migration. Internally still performs an epoll_wait, so
+// it violates the single-epoll_wait constraint. New code must use
+// start() + handle_event() and let the main loop own epoll_wait().
+Result<std::string> CgiDelegate::execute(int timeout_ms, EPoll *epoll) {
+  (void)timeout_ms;
+  Result<Void> s = start(epoll);
+  if (!s.has_value()) {
+    return ERR(std::string, s.error());
+  }
+  while (!is_done()) {
+    Result<Events> wait_result = epoll->wait(timeout_ms > 0 ? timeout_ms : -1);
+    if (!wait_result.has_value()) {
+      _fail("EPoll wait failed");
+      return ERR(std::string, _error);
+    }
+    Events events = wait_result.value();
+    if (events.is_end()) {
+      _fail("CGI execution timeout");
+      return ERR(std::string, _error);
+    }
+    for (; !events.is_end(); ++events) {
+      Result<const Event *> ev_res = *events;
+      if (!ev_res.has_value())
+        continue;
+      Result<Void> he = handle_event(ev_res.value());
+      (void)he;
+      if (is_done())
+        break;
+    }
+  }
+  return result();
 }
 
 CgiDelegate::~CgiDelegate() {
-  // env is now a value member, will be automatically destroyed
+  _cleanup_epoll();
+  if (_pid > 0) {
+    terminate_child(_pid);
+    _pid = -1;
+  }
+  // env is a value member, destroyed automatically
 }

--- a/src/cgi_1_1.h
+++ b/src/cgi_1_1.h
@@ -11,6 +11,9 @@
 // Forward declarations
 class CgiInput;
 class EPoll;
+class Event;
+class FileDescriptor;
+#include <sys/types.h>
 
 class CgiAuthType {
 public:
@@ -560,13 +563,58 @@ public:
 };
 
 class CgiDelegate {
+public:
+  enum State { NOT_STARTED, RUNNING, COMPLETE, FAILED };
+
+private:
   CgiInput env;
   std::string script_path;
   const Request& request;
 
+  // Execution state. epoll_wait() is NOT performed inside this class; the
+  // main event loop is the sole owner of epoll_wait() and drives the
+  // delegate through start()/handle_event() until is_done() is true.
+  State _state;
+  EPoll *_epoll;          // borrowed, not owned
+  pid_t _pid;
+  int _stdin_raw;         // raw write end of stdin pipe; -1 when closed
+  int _stdout_raw;        // raw read end of stdout pipe; -1 when closed
+  FileDescriptor *_stdin_epoll;   // non-null while registered in epoll
+  FileDescriptor *_stdout_epoll;  // non-null while registered in epoll
+  std::string _body;
+  size_t _total_written;
+  std::string _output;
+  std::string _error;
+
+  void _fail(const std::string &msg);
+  void _cleanup_epoll();
+
 public:
   CgiDelegate(const Request &req, const std::string &script);
+
+  // Phase 1: create pipes, fork, register the pipe fds with epoll.
+  // After this returns OK, the main event loop will deliver events on the
+  // registered fds; the caller must route them to handle_event().
+  Result<Void> start(EPoll *epoll);
+
+  // Phase 2: process a single epoll event for this CGI. Performs
+  // non-blocking IO only; never calls epoll->wait(). Returns an error if
+  // the CGI fails, in which case is_done() also becomes true.
+  Result<Void> handle_event(const Event *ev);
+
+  bool is_done() const { return _state == COMPLETE || _state == FAILED; }
+  State state() const { return _state; }
+
+  // Retrieve the script output. Valid once is_done() is true.
+  Result<std::string> result() const;
+
+  // DEPRECATED convenience wrapper that drives start() + handle_event()
+  // using the given epoll directly. Kept only so existing synchronous
+  // callers continue to compile while they migrate to the event-loop
+  // API above. New code MUST use start()/handle_event() and let the main
+  // loop be the sole owner of epoll_wait().
   Result<std::string> execute(int timeout_ms, EPoll *epoll);
+
   ~CgiDelegate();
 };
 

--- a/src/uwsgi.cpp
+++ b/src/uwsgi.cpp
@@ -312,39 +312,43 @@ Result<UwsgiInput> UwsgiInput::Parser::parse(Http::Request const &req) {
 
 // UwsgiDelegate implementation
 
-// Returns remaining milliseconds until the deadline.
-// -1 = no deadline (epoll_wait blocks indefinitely).
-// 0  = deadline already passed.
-static int uwsgi_remaining_ms(long long start_ms, int timeout_ms) {
-  if (timeout_ms <= 0)
-    return -1;
-  struct timeval tv_now;
-  gettimeofday(&tv_now, NULL);
-  long long now_ms = (long long)tv_now.tv_sec * 1000 + tv_now.tv_usec / 1000;
-  if (now_ms < start_ms)
-    return timeout_ms;
-  long long rem = (long long)timeout_ms - (now_ms - start_ms);
-  return (rem > 0) ? (int)rem : 0;
-}
-
 UwsgiDelegate::UwsgiDelegate(const Http::Request &req, int uwsgi_port)
-    : env(req), _uwsgi_port(uwsgi_port), request(req) {
+    : env(req), _uwsgi_port(uwsgi_port), request(req),
+      _state(NOT_STARTED), _epoll(NULL), _raw_sock(-1),
+      _sock_epoll(NULL), _send_buf(), _total_sent(0), _output(),
+      _response(NULL), _error() {
   Result<UwsgiInput> env_result = UwsgiInput::Parser::parse(req);
   if (env_result.error().empty()) {
     env = env_result.value();
   }
 }
 
-Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
-  if (epoll == NULL) {
-    return ERR(Http::Response, "EPoll instance required");
+void UwsgiDelegate::_cleanup_epoll() {
+  if (_epoll != NULL && _sock_epoll != NULL) {
+    _epoll->del_fd(*_sock_epoll);
+    _sock_epoll = NULL;
   }
+  _raw_sock = -1;
+}
 
-  // Capture start time for end-to-end deadline tracking
-  struct timeval tv_start;
-  gettimeofday(&tv_start, NULL);
-  long long start_ms =
-      (long long)tv_start.tv_sec * 1000 + tv_start.tv_usec / 1000;
+void UwsgiDelegate::_fail(const std::string &msg) {
+  _state = FAILED;
+  _error = msg;
+  _cleanup_epoll();
+}
+
+// Phase 1: build the uwsgi packet, open a non-blocking TCP socket to the
+// uwsgi server, and register it with the shared epoll for writability so
+// the connect completion notifies through the caller's main event loop.
+// epoll_wait() is NEVER called from this class.
+Result<Void> UwsgiDelegate::start(EPoll *epoll) {
+  if (epoll == NULL) {
+    return ERR(Void, "EPoll instance required");
+  }
+  if (_state != NOT_STARTED) {
+    return ERR(Void, "UwsgiDelegate::start() already called");
+  }
+  _epoll = epoll;
 
   // Collect CGI/HTTP vars from the parsed WSGI environment
   std::map<std::string, std::string> vars = env.to_map();
@@ -399,8 +403,11 @@ Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
     vars_block.push_back(static_cast<unsigned char>((val_len >> 8) & 0xFF));
     vars_block.insert(vars_block.end(), val.begin(), val.end());
   }
-  if (vars_block.size() > static_cast<size_t>(USHRT_MAX))
-    return ERR(Http::Response, "uwsgi vars block exceeds 64 KiB limit");
+  if (vars_block.size() > static_cast<size_t>(USHRT_MAX)) {
+    _state = FAILED;
+    _error = "uwsgi vars block exceeds 64 KiB limit";
+    return ERR(Void, _error);
+  }
 
   // 4-byte uwsgi header: [modifier1=0][datasize:2B LE][modifier2=0]
   unsigned short datasize = static_cast<unsigned short>(vars_block.size());
@@ -410,11 +417,12 @@ Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
   uwsgi_header[2] = static_cast<unsigned char>((datasize >> 8) & 0xFF);
   uwsgi_header[3] = 0;
 
-  // Build the full send buffer: header + vars_block + body
-  std::vector<unsigned char> send_buf;
-  send_buf.insert(send_buf.end(), uwsgi_header, uwsgi_header + 4);
-  send_buf.insert(send_buf.end(), vars_block.begin(), vars_block.end());
-  send_buf.insert(send_buf.end(), body_str.begin(), body_str.end());
+  // Build the full send buffer (header + vars_block + body) into the
+  // member so it persists across handle_event() calls.
+  _send_buf.clear();
+  _send_buf.insert(_send_buf.end(), uwsgi_header, uwsgi_header + 4);
+  _send_buf.insert(_send_buf.end(), vars_block.begin(), vars_block.end());
+  _send_buf.insert(_send_buf.end(), body_str.begin(), body_str.end());
 
   // Create a non-blocking TCP socket and connect to 127.0.0.1:_uwsgi_port
   struct addrinfo hints, *res = NULL;
@@ -423,226 +431,115 @@ Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
   hints.ai_socktype = SOCK_STREAM;
   std::ostringstream port_ss;
   port_ss << _uwsgi_port;
-  if (getaddrinfo("127.0.0.1", port_ss.str().c_str(), &hints, &res) != 0)
-    return ERR(Http::Response, "uwsgi: failed to resolve server address");
+  if (getaddrinfo("127.0.0.1", port_ss.str().c_str(), &hints, &res) != 0) {
+    _state = FAILED;
+    _error = "uwsgi: failed to resolve server address";
+    return ERR(Void, _error);
+  }
 
   int raw_sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
   if (raw_sock < 0) {
     freeaddrinfo(res);
-    return ERR(Http::Response, "uwsgi: failed to create socket");
+    _state = FAILED;
+    _error = "uwsgi: failed to create socket";
+    return ERR(Void, _error);
   }
 
-  // Wrap in FileDescriptor so it is automatically closed when it goes out of
-  // scope (FileDescriptor destructor closes the fd)
+  // Wrap so the fd is automatically closed. add_fd takes ownership.
   Result<FileDescriptor> sock_fd_res = FileDescriptor::from_raw(raw_sock);
   if (!sock_fd_res.error().empty()) {
     freeaddrinfo(res);
     close(raw_sock);
-    return ERR(Http::Response, "uwsgi: failed to wrap socket fd");
+    _state = FAILED;
+    _error = "uwsgi: failed to wrap socket fd";
+    return ERR(Void, _error);
   }
   FileDescriptor sock_fd = sock_fd_res.value();
 
-  // Set non-blocking so we can use epoll
   Result<Void> nb_res = sock_fd.set_nonblocking();
   if (!nb_res.error().empty()) {
     freeaddrinfo(res);
-    return ERR(Http::Response, "uwsgi: failed to set socket non-blocking");
+    _state = FAILED;
+    _error = "uwsgi: failed to set socket non-blocking";
+    return ERR(Void, _error);
   }
 
-  // Start non-blocking connect; EINPROGRESS is expected
   int conn_ret = connect(raw_sock, res->ai_addr, res->ai_addrlen);
   freeaddrinfo(res);
   if (conn_ret < 0 && errno != EINPROGRESS) {
-    return ERR(Http::Response, "uwsgi: connect failed");
+    _state = FAILED;
+    _error = "uwsgi: connect failed";
+    return ERR(Void, _error);
   }
 
-  // Add socket to epoll, monitoring for writability (connect completion) and
-  // errors
+  _raw_sock = raw_sock;
+
+  // Monitor for writability (connect completion) and errors.
   const FileDescriptor *sock_fd_ptr = &sock_fd;
-  Event connect_event(sock_fd_ptr, false, true, false, false, true, false);
+  Event connect_event(sock_fd_ptr, false, true, false, false, true, true);
   Option connect_option(false, false, false, false);
   Result<FileDescriptor *> add_res =
-      epoll->add_fd(sock_fd, connect_event, connect_option);
+      _epoll->add_fd(sock_fd, connect_event, connect_option);
   if (!add_res.has_value()) {
-    return ERR(Http::Response, "uwsgi: failed to add socket to epoll");
+    _raw_sock = -1;
+    _state = FAILED;
+    _error = "uwsgi: failed to add socket to epoll";
+    return ERR(Void, _error);
   }
-  FileDescriptor *sock_epoll = add_res.value();
+  _sock_epoll = add_res.value();
 
-  // Wait for connect to complete
-  bool connected = false;
-  while (!connected) {
-    int rem = uwsgi_remaining_ms(start_ms, timeout_ms);
-    if (rem == 0) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout waiting for connect");
-    }
-    Result<Events> wait_res = epoll->wait(rem);
-    if (!wait_res.error().empty()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: epoll wait failed during connect");
-    }
-    Events events = wait_res.value();
-    if (events.is_end()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout waiting for connect");
-    }
-    for (; !events.is_end(); ++events) {
-      Result<const Event *> ev_res = *events;
-      if (!ev_res.error().empty())
-        continue;
-      const Event *ev = ev_res.value();
-      if (*ev->fd == raw_sock) {
-        if (ev->err || ev->hup) {
-          epoll->del_fd(*sock_epoll);
-          return ERR(Http::Response, "uwsgi: connect error");
-        }
-        if (ev->out) {
-          // Verify connect succeeded via getsockopt
-          int sock_err = 0;
-          socklen_t sock_err_len = sizeof(sock_err);
-          if (getsockopt(raw_sock, SOL_SOCKET, SO_ERROR, &sock_err,
-                         &sock_err_len) == 0 &&
-              sock_err == 0) {
-            connected = true;
-          } else {
-            epoll->del_fd(*sock_epoll);
-            return ERR(Http::Response, "uwsgi: connect failed (SO_ERROR)");
-          }
-        }
-      }
-    }
+  _state = (conn_ret == 0) ? SENDING : CONNECTING;
+  return OKV;
+}
+
+Result<Void> UwsgiDelegate::_switch_to_sending() {
+  if (_sock_epoll == NULL)
+    return ERR(Void, "uwsgi: internal state: socket not registered");
+  const FileDescriptor *sock_fd_ptr = _sock_epoll;
+  Event write_event(sock_fd_ptr, false, true, false, false, true, true);
+  Option write_option(false, false, false, false);
+  _epoll->modify_fd(*_sock_epoll, write_event, write_option);
+  _state = SENDING;
+  return OKV;
+}
+
+Result<Void> UwsgiDelegate::_switch_to_receiving() {
+  if (_sock_epoll == NULL)
+    return ERR(Void, "uwsgi: internal state: socket not registered");
+  // Half-close the write side so the server sees EOF on the request.
+  shutdown(_raw_sock, SHUT_WR);
+  const FileDescriptor *sock_fd_ptr = _sock_epoll;
+  Event read_event(sock_fd_ptr, true, false, true, false, true, true);
+  Option read_option(false, false, false, false);
+  _epoll->modify_fd(*_sock_epoll, read_event, read_option);
+  _state = RECEIVING;
+  return OKV;
+}
+
+Result<Void> UwsgiDelegate::_parse_response() {
+  if (_output.empty()) {
+    _state = FAILED;
+    _error = "Empty response from uwsgi server";
+    return ERR(Void, _error);
   }
 
-  // Switch epoll interest to WRITE for sending the request
-  {
-    Event write_event(sock_fd_ptr, false, true, false, false, false, false);
-    Option write_option(false, false, false, false);
-    epoll->modify_fd(*sock_epoll, write_event, write_option);
-  }
-
-  // Send the entire send_buf using epoll-backed non-blocking writes
-  size_t total_sent = 0;
-  while (total_sent < send_buf.size()) {
-    int rem = uwsgi_remaining_ms(start_ms, timeout_ms);
-    if (rem == 0) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout during send");
-    }
-    Result<Events> wait_res = epoll->wait(rem);
-    if (!wait_res.error().empty()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: epoll wait failed during send");
-    }
-    Events events = wait_res.value();
-    if (events.is_end()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout during send");
-    }
-    bool fd_ready = false;
-    for (; !events.is_end(); ++events) {
-      Result<const Event *> ev_res = *events;
-      if (!ev_res.error().empty())
-        continue;
-      const Event *ev = ev_res.value();
-      if (*ev->fd == raw_sock && ev->out) {
-        fd_ready = true;
-        break;
-      }
-    }
-    if (!fd_ready)
-      continue;
-
-    ssize_t written = write(
-        raw_sock, reinterpret_cast<const char *>(&send_buf[0]) + total_sent,
-        send_buf.size() - total_sent);
-    if (written < 0) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: write failed");
-    } else if (written == 0) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: connection closed during send");
-    }
-    total_sent += static_cast<size_t>(written);
-  }
-
-  // Half-close the write side so the uwsgi server sees EOF on the request
-  shutdown(raw_sock, SHUT_WR);
-
-  // Switch epoll interest to READ for receiving the response
-  {
-    Event read_event(sock_fd_ptr, true, false, false, false, false, false);
-    Option read_option(false, false, false, false);
-    epoll->modify_fd(*sock_epoll, read_event, read_option);
-  }
-
-  // Read the full response using epoll-backed non-blocking reads
-  std::string output;
-  char read_buf[4096];
-  while (true) {
-    int rem = uwsgi_remaining_ms(start_ms, timeout_ms);
-    if (rem == 0) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout during receive");
-    }
-    Result<Events> wait_res = epoll->wait(rem);
-    if (!wait_res.error().empty()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: epoll wait failed during receive");
-    }
-    Events events = wait_res.value();
-    if (events.is_end()) {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: timeout during receive");
-    }
-    bool fd_ready = false;
-    for (; !events.is_end(); ++events) {
-      Result<const Event *> ev_res = *events;
-      if (!ev_res.error().empty())
-        continue;
-      const Event *ev = ev_res.value();
-      if (*ev->fd == raw_sock && (ev->in || ev->rdhup || ev->hup)) {
-        fd_ready = true;
-        break;
-      }
-    }
-    if (!fd_ready)
-      continue;
-
-    ssize_t n = read(raw_sock, read_buf, sizeof(read_buf));
-    if (n > 0) {
-      output.append(read_buf, static_cast<size_t>(n));
-    } else if (n == 0) {
-      break; // EOF: server closed connection
-    } else {
-      epoll->del_fd(*sock_epoll);
-      return ERR(Http::Response, "uwsgi: read error receiving response");
-    }
-  }
-
-  epoll->del_fd(*sock_epoll);
-
-  if (output.empty())
-    return ERR(Http::Response, "Empty response from uwsgi server");
-
-  // Parse WSGI output to extract headers and body
   std::string headers_section;
   std::string body_section;
-  size_t blank_line_pos = output.find("\r\n\r\n");
+  size_t blank_line_pos = _output.find("\r\n\r\n");
 
   if (blank_line_pos == std::string::npos) {
-    blank_line_pos = output.find("\n\n");
+    blank_line_pos = _output.find("\n\n");
     if (blank_line_pos != std::string::npos) {
-      headers_section = output.substr(0, blank_line_pos);
-      body_section = output.substr(blank_line_pos + 2);
+      headers_section = _output.substr(0, blank_line_pos);
+      body_section = _output.substr(blank_line_pos + 2);
     } else {
-      body_section = output;
+      body_section = _output;
     }
   } else {
-    headers_section = output.substr(0, blank_line_pos);
-    body_section = output.substr(blank_line_pos + 4);
+    headers_section = _output.substr(0, blank_line_pos);
+    body_section = _output.substr(blank_line_pos + 4);
   }
 
-  // Parse response headers
   std::map<std::string, std::string> response_headers;
   int status_code = 200;
 
@@ -673,10 +570,164 @@ Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
   Http::Body::Value body_val;
   body_val.html_raw = new std::string(body_section);
   Http::Body result_body(Http::Body::Html, body_val);
-  Http::Response response(status_code, response_headers, result_body);
-  return OK(Http::Response, response);
+  delete _response;
+  _response = new Http::Response(status_code, response_headers, result_body);
+  return OKV;
+}
+
+// Phase 2: drive the state machine based on a single epoll event.
+Result<Void> UwsgiDelegate::handle_event(const Event *ev) {
+  if (_state == COMPLETE || _state == FAILED || _state == NOT_STARTED) {
+    return OKV;
+  }
+  if (ev == NULL || ev->fd == NULL) {
+    return OKV;
+  }
+  if (_sock_epoll == NULL || _raw_sock == -1) {
+    return OKV;
+  }
+  if (*ev->fd != _raw_sock) {
+    return OKV; // not our socket
+  }
+
+  if (_state == CONNECTING) {
+    if (ev->err || ev->hup) {
+      _fail("uwsgi: connect error");
+      return ERR(Void, _error);
+    }
+    if (ev->out) {
+      int sock_err = 0;
+      socklen_t sock_err_len = sizeof(sock_err);
+      if (getsockopt(_raw_sock, SOL_SOCKET, SO_ERROR, &sock_err,
+                     &sock_err_len) == 0 &&
+          sock_err == 0) {
+        Result<Void> sw = _switch_to_sending();
+        if (!sw.has_value()) {
+          _fail(sw.error());
+          return ERR(Void, _error);
+        }
+      } else {
+        _fail("uwsgi: connect failed (SO_ERROR)");
+        return ERR(Void, _error);
+      }
+    }
+    // Already in SENDING after _switch_to_sending; fall through to try a
+    // first write if the same event also reported writability.
+  }
+
+  if (_state == SENDING) {
+    if (ev->err) {
+      _fail("uwsgi: socket error during send");
+      return ERR(Void, _error);
+    }
+    if (ev->out && _total_sent < _send_buf.size()) {
+      ssize_t written = write(
+          _raw_sock,
+          reinterpret_cast<const char *>(&_send_buf[0]) + _total_sent,
+          _send_buf.size() - _total_sent);
+      if (written < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+          return OKV;
+        }
+        _fail("uwsgi: write failed");
+        return ERR(Void, _error);
+      } else if (written == 0) {
+        _fail("uwsgi: connection closed during send");
+        return ERR(Void, _error);
+      }
+      _total_sent += static_cast<size_t>(written);
+    }
+    if (_total_sent >= _send_buf.size()) {
+      Result<Void> sw = _switch_to_receiving();
+      if (!sw.has_value()) {
+        _fail(sw.error());
+        return ERR(Void, _error);
+      }
+    }
+    return OKV;
+  }
+
+  if (_state == RECEIVING) {
+    if (ev->err && !ev->in && !ev->hup && !ev->rdhup) {
+      _fail("uwsgi: socket error during receive");
+      return ERR(Void, _error);
+    }
+    if (ev->in || ev->rdhup || ev->hup) {
+      char read_buf[4096];
+      ssize_t n = read(_raw_sock, read_buf, sizeof(read_buf));
+      if (n > 0) {
+        _output.append(read_buf, static_cast<size_t>(n));
+        return OKV;
+      }
+      if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+          return OKV;
+        }
+        _fail("uwsgi: read error receiving response");
+        return ERR(Void, _error);
+      }
+
+      // n == 0: EOF, server finished sending.
+      _cleanup_epoll();
+      Result<Void> p = _parse_response();
+      if (!p.has_value()) {
+        return ERR(Void, _error);
+      }
+      _state = COMPLETE;
+      return OKV;
+    }
+    return OKV;
+  }
+
+  return OKV;
+}
+
+// DEPRECATED: synchronous wrapper retained only so that legacy callers
+// compile during migration. Internally still performs an epoll_wait, so
+// it violates the single-epoll_wait constraint. New code must use
+// start() + handle_event() and let the main loop own epoll_wait().
+Result<Http::Response> UwsgiDelegate::execute(int timeout_ms, EPoll *epoll) {
+  Result<Void> s = start(epoll);
+  if (!s.has_value()) {
+    return ERR(Http::Response, s.error());
+  }
+  while (!is_done()) {
+    Result<Events> wait_result = epoll->wait(timeout_ms > 0 ? timeout_ms : -1);
+    if (!wait_result.has_value()) {
+      _fail("uwsgi: epoll wait failed");
+      return ERR(Http::Response, _error);
+    }
+    Events events = wait_result.value();
+    if (events.is_end()) {
+      _fail("uwsgi: execution timeout");
+      return ERR(Http::Response, _error);
+    }
+    for (; !events.is_end(); ++events) {
+      Result<const Event *> ev_res = *events;
+      if (!ev_res.has_value())
+        continue;
+      Result<Void> he = handle_event(ev_res.value());
+      (void)he;
+      if (is_done())
+        break;
+    }
+  }
+  return result();
+}
+
+Result<Http::Response> UwsgiDelegate::result() const {
+  if (_state == FAILED) {
+    return ERR(Http::Response, _error);
+  }
+  if (_state != COMPLETE || _response == NULL) {
+    return ERR(Http::Response, "uwsgi execution not complete");
+  }
+  return OK(Http::Response, *_response);
 }
 
 UwsgiDelegate::~UwsgiDelegate() {
-  // env is now a value member, will be automatically destroyed
+  _cleanup_epoll();
+  delete _response;
+  _response = NULL;
+  // env is a value member, destroyed automatically
 }

--- a/src/uwsgi.h
+++ b/src/uwsgi.h
@@ -11,6 +11,8 @@
 // Forward declarations
 class UwsgiInput;
 class EPoll;
+class Event;
+class FileDescriptor;
 
 class UwsgiMetaVar {
 public:
@@ -96,13 +98,61 @@ public:
 };
 
 class UwsgiDelegate {
+public:
+  enum State {
+    NOT_STARTED,
+    CONNECTING,
+    SENDING,
+    RECEIVING,
+    COMPLETE,
+    FAILED
+  };
+
+private:
   UwsgiInput env;
   int _uwsgi_port;
   Http::Request request;
 
+  State _state;
+  EPoll *_epoll;             // borrowed, not owned
+  int _raw_sock;             // raw socket fd; -1 when not registered
+  FileDescriptor *_sock_epoll; // non-null while registered in epoll
+  std::vector<unsigned char> _send_buf;
+  size_t _total_sent;
+  std::string _output;
+  Http::Response *_response; // built lazily on successful completion
+  std::string _error;
+
+  void _fail(const std::string &msg);
+  void _cleanup_epoll();
+  Result<Void> _switch_to_sending();
+  Result<Void> _switch_to_receiving();
+  Result<Void> _parse_response();
+
 public:
   UwsgiDelegate(const Http::Request &req, int uwsgi_port);
+
+  // Phase 1: create the socket, issue a non-blocking connect to the uwsgi
+  // server, and register the socket with the shared epoll. Does NOT call
+  // epoll->wait().
+  Result<Void> start(EPoll *epoll);
+
+  // Phase 2: process a single epoll event delivered by the main loop's
+  // shared epoll_wait. Drives the connect -> send -> receive state
+  // machine; performs only non-blocking IO.
+  Result<Void> handle_event(const Event *ev);
+
+  bool is_done() const { return _state == COMPLETE || _state == FAILED; }
+  State state() const { return _state; }
+
+  // Retrieve the parsed HTTP response. Valid once is_done() is true.
+  Result<Http::Response> result() const;
+
+  // DEPRECATED convenience wrapper. Kept so existing synchronous callers
+  // compile while they migrate to start()/handle_event(). New code MUST
+  // use start()/handle_event() and let the main loop own epoll_wait().
   Result<Http::Response> execute(int timeout_ms, EPoll *epoll);
+
   ~UwsgiDelegate();
 };
 


### PR DESCRIPTION
## Summary

The delegates previously called `epoll->wait()` inside their `execute()` methods, which conflicts with the "single `epoll_wait` per application" rule the main event loop needs to own. Both classes are now split into two phases:

- `start(epoll)` — sets up pipes/socket, forks (CGI) or issues non-blocking `connect()` (uwsgi), and registers fds with the shared epoll. No `epoll_wait` is called.
- `handle_event(ev)` — consumes one event delivered by the main loop's `epoll_wait`, performing only non-blocking IO. Drives the internal state machine until `is_done()` is true, after which `result()` returns the output (CGI) or parsed `Http::Response` (uwsgi).

### CGI (`src/cgi_1_1.{h,cpp}`)
- `start()` creates stdin/stdout pipes, forks, sets parent ends non-blocking, and registers them (stdin for `EPOLLOUT` only when there's a body; stdout for `EPOLLIN | HUP`).
- `handle_event()` writes body chunks on stdin-writable, reads on stdout-readable, and on stdout EOF detaches from epoll and reaps the child with `waitpid_nohang` (preserving the `WIFEXITED` / `WEXITSTATUS` check).

### uwsgi (`src/uwsgi.{h,cpp}`)
- `start()` builds the uwsgi packet, opens a non-blocking TCP socket, issues `connect()` (`EINPROGRESS` OK), and registers with epoll. Enters `CONNECTING` (or `SENDING` if connect completes immediately).
- `handle_event()` drives `CONNECTING -> SENDING -> RECEIVING -> COMPLETE`, using `getsockopt(SO_ERROR)` to confirm connect completion, `modify_fd` to swap `EPOLLOUT` / `EPOLLIN` interest, and `shutdown(SHUT_WR)` before reading the response.

Both destructors clean up any still-registered epoll entries and (for CGI) terminate a lingering child.

### Backward compatibility

`server/Response.cpp` still calls `execute(timeout_ms, epoll)` and was out of scope for this change, so `execute()` is kept as a deprecated thin wrapper that drives `start()` + `handle_event()` and is the only place that still calls `epoll->wait()` internally. Both headers mark it DEPRECATED; it should be removed once the main event loop is migrated to the split API.

## Test plan

- [x] `make` — full build succeeds with `-Wall -Werror -Wextra -Wconversion -std=c++98`.
- [x] `make integration-test` — `tests/integration/cgi_uwsgi_full_suite.sh` passes ("CGI and uWSGI full integration suite passed").
- [ ] Manually verify behavior once `server/Response.cpp` is migrated to `start()` / `handle_event()` driven by the main event loop.